### PR TITLE
市场包配置文件格式调整

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "gruntplugin"
   ],
   "dependencies": {
+    "art-template": "^3.0.3",
     "chalk": "^1.0.0",
     "lodash": "^3.3.1"
   }

--- a/tasks/template/index.tpl
+++ b/tasks/template/index.tpl
@@ -1,0 +1,21 @@
+(function(){
+
+var prefix = KISSY.config('assetsPrefix') || '//g.alicdn.com/';
+var base = prefix+'{{config.group}}/{{config.name}}/{{config.version}}';
+
+KISSY.config({
+    '{{config.name}}': {
+        'manifest': 1,
+        'version': '{{config.version}}',
+        'base': base,
+        'mods': [{{modStr}}]
+    },
+    'packages': [{
+        'name': '{{config.name}}',
+        'base': base,
+        'group': '{{config.group}}',
+        'ignorePackageNameInUri': true
+    }{{packageStr}}]{{moduleStr}}
+});
+
+})();

--- a/test/expected/index.js
+++ b/test/expected/index.js
@@ -1,10 +1,19 @@
+(function(){
+
+var prefix = KISSY.config('assetsPrefix') || '//g.alicdn.com/';
+var base = prefix+'tb/lego-market-test/1.0.1';
+
 KISSY.config({
     'lego-market-test': {
-        mods: ['address', 'confirmOrder']
+        'manifest': 1,
+        'version': '1.0.1',
+        'base': base,
+        'mods': ['address', 'confirmOrder']
     },
     'packages': [{
         'name': 'lego-market-test',
-        'base': 'http://g.alicdn.com/lego-market-test/1.0.1',
+        'base': base,
+        'group': 'tb',
         'ignorePackageNameInUri': true
     }, {
         'name': 'fp',
@@ -15,3 +24,5 @@ KISSY.config({
         'mui/view-port-listen': {"requires":["base","node"],"path":"mui/view-port-listen/1.0.3/index.js"}
     }
 });
+
+})();

--- a/test/result/index.js
+++ b/test/result/index.js
@@ -1,10 +1,19 @@
+(function(){
+
+var prefix = KISSY.config('assetsPrefix') || '//g.alicdn.com/';
+var base = prefix+'tb/lego-market-test/1.0.1';
+
 KISSY.config({
     'lego-market-test': {
-        mods: ['address', 'confirmOrder']
+        'manifest': 1,
+        'version': '1.0.1',
+        'base': base,
+        'mods': ['address', 'confirmOrder']
     },
     'packages': [{
         'name': 'lego-market-test',
-        'base': 'http://g.alicdn.com/lego-market-test/1.0.1',
+        'base': base,
+        'group': 'tb',
         'ignorePackageNameInUri': true
     }, {
         'name': 'fp',
@@ -15,3 +24,5 @@ KISSY.config({
         'mui/view-port-listen': {"requires":["base","node"],"path":"mui/view-port-listen/1.0.3/index.js"}
     }
 });
+
+})();

--- a/test/src/config.json
+++ b/test/src/config.json
@@ -1,5 +1,6 @@
 {
     "name": "lego-market-test",
+    "group": "tb",
     "version": "1.0.1",
     "dependencies": {
         "packages": [{


### PR DESCRIPTION
hi，自寒：

市场包的配置文件格式有些调整。。

主要是为了本地开发调试方便和支持loader的样式combo功能

配置里我加入了一个manifest字段，是留给以后的版本做兼容处理的，其他的修改：
- 支持从assetsPrefix配置中获取静态文件前缀，方便开发调试
- 修改market配置，加入base项，lego-loader会使用这个base拼接样式的combo文件地址
- 修改market包配置，加入group项

帮忙做下合并和发布哈，修改有点大，建议用0.2.0版本发布吧：)
